### PR TITLE
Try to fix proxy trust settings

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -28,6 +28,8 @@ if (!process.env.JEST_WORKER_ID) {
 const csrfProtection = csrf({ cookie: true, secure: true });
 
 const app = express();
+app.set('trust proxy', true);
+app.set('trust proxy', 'loopback');
 app.use(cors());
 app.use(passport.initialize());
 app.use(compression());

--- a/backend/app.js
+++ b/backend/app.js
@@ -28,8 +28,8 @@ if (!process.env.JEST_WORKER_ID) {
 const csrfProtection = csrf({ cookie: true, secure: true });
 
 const app = express();
-app.set('trust proxy', true);
-app.set('trust proxy', 'loopback');
+app.set("trust proxy", true);
+app.set("trust proxy", "loopback");
 app.use(cors());
 app.use(passport.initialize());
 app.use(compression());


### PR DESCRIPTION
When deployed, I am getting SSL mismatch errors. I think this is because Express isn't trusting the Nginx proxy it's sitting behind. Hopefully this PR fixes it.